### PR TITLE
Add OpenRouter LLM support

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ To use `Huggingface` models, it is required to save the API access token as an e
   <li> Register or login at <a href="https://huggingface.co">Hugging Face</a> and create an API token in your profile settings </li>
   <li> Add a file called <code>secrets.toml</code> in a folder called <code>.streamlit</code> at the root of the repo, and provide your HuggingFace API token by typing <code>huggingface_token = "..."</code>
   <li> For `OpenAI` models, add the access token <code>openai_token = "YourOpenAITokenHere" </code> to `.streamlit/secrets.toml`. </li>
+  <li> To use models via <a href="https://openrouter.ai">OpenRouter</a>, add <code>openrouter_token = "YourOpenRouterTokenHere"</code> to the same file. Optionally specify <code>openrouter_model = "provider/model-name"</code> to choose a model.</li>
 </ol>
 
 or you can open your shell's configuration file in a text editor: 
@@ -44,6 +45,7 @@ vim ~/.bashrc
 Add the following line to the end of the file:
 ```shell
 export HUGGINGFACEHUB_API_TOKEN="YourHFTokenHere"
+export OPENROUTER_API_KEY="YourOpenRouterTokenHere" # optional
 ```
 Save and close the file. To apply the changes, source the file or restart your terminal:
 ```shell

--- a/gllm/cli.py
+++ b/gllm/cli.py
@@ -37,7 +37,7 @@ def main():
     parser = argparse.ArgumentParser(description="G-code Generator CLI")
     parser.add_argument(
         "--model",
-        choices=["Zephyr-7b", "GPT-3.5", "Fine-tuned StarCoder", "CodeLlama"],
+        choices=["Zephyr-7b", "GPT-3.5", "Fine-tuned StarCoder", "CodeLlama", "OpenRouter"],
         default="GPT-3.5",
         help="Language model to use",
     )

--- a/gllm/code_generator_streamlit_reasoning_langchain_langgraph.py
+++ b/gllm/code_generator_streamlit_reasoning_langchain_langgraph.py
@@ -53,7 +53,7 @@ def main():
     # Drop-down menu for model selection
     model_str = st.selectbox(
         'Choose a Language Model:',
-        ('Zephyr-7b', 'GPT-3.5', 'Fine-tuned StarCoder', 'CodeLlama'),
+        ('Zephyr-7b', 'GPT-3.5', 'Fine-tuned StarCoder', 'CodeLlama', 'OpenRouter'),
         index=1,
     )
 

--- a/gllm/utils/model_utils.py
+++ b/gllm/utils/model_utils.py
@@ -30,6 +30,8 @@ secrets_file_path = os.path.abspath(os.path.join(os.path.dirname('__file__'), '.
 secrets = toml.load(secrets_file_path)
 # Set your OpenAI API key
 openai.api_key = secrets["openai_token"]
+# Optionally set your OpenRouter API key
+openrouter_api_key = secrets.get("openrouter_token")
 
 
 def setup_model(model: str):
@@ -61,6 +63,18 @@ def setup_model(model: str):
         llm = HuggingFacePipeline(pipeline=hf_pipeline)
     elif model == "GPT-3.5":
         llm = ChatOpenAI(model="gpt-3.5-turbo-0125", temperature=0.7, api_key=openai.api_key)
+    elif model == "OpenRouter":
+        openrouter_model = secrets.get("openrouter_model", "openai/gpt-3.5-turbo")
+        llm = ChatOpenAI(
+            model=openrouter_model,
+            temperature=0.7,
+            base_url="https://openrouter.ai/api/v1",
+            api_key=openrouter_api_key,
+            default_headers={
+                "HTTP-Referer": "https://github.com/mohamedyd/GLLM",
+                "X-Title": "GLLM",
+            },
+        )
     elif model == 'CodeLlama':
         # Wrap the model inside a transformers pipeline to ensure text input works with LangChain.
         model_name = "codellama/CodeLlama-7b-hf"


### PR DESCRIPTION
## Summary
- support OpenRouter models via `ChatOpenAI`
- allow selecting `OpenRouter` in CLI and Streamlit UI
- document new `openrouter_token` and optional `openrouter_model` in README
- mention optional `OPENROUTER_API_KEY` environment variable

## Testing
- `poetry run pytest`

------
https://chatgpt.com/codex/tasks/task_e_68559cc6820c832c92c7821ee86ec44f